### PR TITLE
Load environment variables by reading .env.dist file

### DIFF
--- a/.github/workflows/.release-workflow-rc.yml
+++ b/.github/workflows/.release-workflow-rc.yml
@@ -24,8 +24,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Use default environment settings
-        run: cp .env.dist .env
+      - name: Load default environment variables values
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: '.env.dist'
       - name: Build
         run: docker compose -f docker-compose.dev.yaml up -d
       - name: Lint and Test

--- a/.github/workflows/.release-workflow.yml
+++ b/.github/workflows/.release-workflow.yml
@@ -40,8 +40,10 @@ jobs:
         with:
           commit_message: increment version
           branch: develop
-      - name: Use default environment settings
-        run: cp .env.dist .env
+      - name: Load default environment variables values
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: '.env.dist'
       - name: Build
         run: docker compose -f docker-compose.dev.yaml up -d
       - name: Lint and Test


### PR DESCRIPTION
Copying .env.dist to .env will cause complexities with overriding settings when using the resulting Docker image