### PR TITLE
Disabled /dev/shm usage for Chrome instances

### DIFF
--- a/app/selenium_app.py
+++ b/app/selenium_app.py
@@ -17,6 +17,7 @@ def get_webdriver() -> webdriver.Remote:
     chrome_options = Options()
     chrome_options.add_argument("--no-sandbox")
     chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--disable-dev-shm-usage")
 
     capabilities = {
         "browserName": "chrome",


### PR DESCRIPTION
Prevention of crashes on Windows (encountered on one machine).
This option doesn't seem to affect the calculations performance in our case

jdi-testing/jdn-ai#1630