### PR TITLE
Manual default network name definition

### DIFF
--- a/docker-compose.remote_server_dev.yaml
+++ b/docker-compose.remote_server_dev.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 name: jdi-qasp-ml
 services:
   chrome:
@@ -24,7 +22,7 @@ services:
       - "-video-output-dir"
       - "/opt/selenoid/video"
       - "-container-network"
-      - "jdi-qasp-ml_default"
+      - "${JDI_DEFAULT_NETWORK_NAME:-jdi-qasp-ml-dev-default}"
       - "-limit"
       - "${SELENOID_PARALLEL_SESSIONS_COUNT:?set it to the number of parallel running threads supported by your processor (-2 optionally)}"
 
@@ -91,3 +89,7 @@ services:
       driver: "json-file"
       options:
         max-size: "256m"
+
+networks:
+  default:
+    name: ${JDI_DEFAULT_NETWORK_NAME:-jdi-qasp-ml-dev-default}


### PR DESCRIPTION
Closes jdi-testing/jdn-ai#1603

> Требуются следующие изменения в указанном файле:
> 1. services -> chrome -> attach не может быть обработан. Нужно удалить этот атрибут.
> 2. services -> selenoid -> command -> имя container-network захардкожено, должно иметь значение действительно равное имени используемой в контейнере сети.
> 3. Запуск получется производить только с дополнительным параметром PWD=${PWD}
(sudo PWD=${PWD} docker compose -p jdi_dev -f docker-compose.remote_server_dev.yaml up -d)
внести эту переменную в docker-compose файл, чтобы убрать параметр из используемой команды.
Если по каким-то причинам это невозможно - обновить используемую команду в документации: https://jdi-family.atlassian.net/wiki/spaces/JDN/pages/44728321/Back-end+server+in+EPAM+Cloud

1. Неактуально, обновлен docker-compose на сервере, новая версия поддерживает атрибут `attach` у сервисов.
2. Сделано.
3. Не совсем актуально, решается добавлением пользователя в группу `docker` и запуском `docker compose` без `sudo`. В документации кстати упоминаний `PWD` нет.